### PR TITLE
Develop 브랜치 병합: 참여 기능 구현 및 버그 수정

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,6 +11,7 @@ import { TagModule } from './tag/tag.module';
 import { FriendshipModule } from './friendship/friendship.module';
 import { PostModule } from './post/post.module';
 import { ReviewModule } from './review/review.module';
+import { ParticipantModule } from './participant/participant.module';
 
 @Module({
   imports: [
@@ -27,6 +28,7 @@ import { ReviewModule } from './review/review.module';
     FriendshipModule,
     PostModule,
     ReviewModule,
+    ParticipantModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -15,7 +15,7 @@ import { UserOauth } from './entities/user-oauth.entity';
 import { UserRating } from './entities/user-rating.entity';
 import { User } from './entities/user.entity';
 import { PostParticipant } from './entities/post-participant.entity';
-import { PostParticipationRequest } from './entities/post-participant-request.entity';
+import { PostParticipationRequest } from './entities/post-participation-request.entity';
 
 config();
 const configService = new ConfigService();

--- a/src/entities/post-participant.entity.ts
+++ b/src/entities/post-participant.entity.ts
@@ -7,23 +7,29 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
 } from 'typeorm';
+import { ApiProperty } from '@nestjs/swagger';
 import { Post } from './post.entity';
 import { User } from './user.entity';
 
 @Entity('post_participant')
 export class PostParticipant {
+  @ApiProperty({ description: '참여자 ID' })
   @PrimaryGeneratedColumn({ name: 'participant_id' })
   participantId: number;
 
+  @ApiProperty({ description: '게시글 ID' })
   @Column({ name: 'post_id' })
   postId: number;
 
+  @ApiProperty({ description: '사용자 ID' })
   @Column({ name: 'user_id' })
   userId: number;
 
+  @ApiProperty({ description: '생성 일시' })
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
 
+  @ApiProperty({ description: '수정 일시' })
   @UpdateDateColumn({ name: 'updated_at' })
   updatedAt: Date;
 

--- a/src/entities/post-participation-request.entity.ts
+++ b/src/entities/post-participation-request.entity.ts
@@ -5,25 +5,27 @@ import {
   ManyToOne,
   JoinColumn,
 } from 'typeorm';
+import { ApiProperty } from '@nestjs/swagger';
 import { Post } from './post.entity';
 import { User } from './user.entity';
 
 @Entity('post_participation_request')
 export class PostParticipationRequest {
+  @ApiProperty({ description: '요청 ID(프라이머리 키)' })
   @PrimaryGeneratedColumn({ name: 'request_id' })
   requestId: number;
 
+  @ApiProperty({ description: '게시글 ID' })
   @Column({ name: 'post_id' })
   postId: number;
 
+  @ApiProperty({ description: '요청자 ID' })
   @Column({ name: 'requester_id' })
   requesterId: number;
 
+  @ApiProperty({ description: '수신자 ID' })
   @Column({ name: 'addressee_id' })
   addresseeId: number;
-
-  @Column({ name: 'status', type: 'boolean' })
-  status: boolean;
 
   @ManyToOne(() => Post, (post) => post.participationRequests)
   @JoinColumn({ name: 'post_id' })

--- a/src/entities/post.entity.ts
+++ b/src/entities/post.entity.ts
@@ -8,41 +8,68 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
 } from 'typeorm';
+import { ApiProperty } from '@nestjs/swagger';
 import { User } from './user.entity';
 import { Location } from './location.entity';
 import { PostTag } from './post-tag.entity';
-import { PostParticipationRequest } from './post-participant-request.entity';
+import { PostParticipationRequest } from './post-participation-request.entity';
 import { PostParticipant } from './post-participant.entity';
 
 @Entity('post')
 export class Post {
+  @ApiProperty({ description: '게시글 ID', example: 1 })
   @PrimaryGeneratedColumn({ name: 'post_id' })
   postId: number;
 
+  @ApiProperty({ description: '사용자 ID', example: 1 })
   @Column({ name: 'user_id' })
   userId: number;
 
+  @ApiProperty({ description: '위치 ID', example: 1 })
   @Column({ name: 'location_id' })
   locationId: number;
 
+  @ApiProperty({ description: '게시글 제목', example: 'NestJS 게시글 예제' })
   @Column({ name: 'title', length: 255 })
   title: string;
 
+  @ApiProperty({
+    description: '게시글 내용',
+    example: '이것은 예제 게시글입니다.',
+  })
   @Column({ name: 'content', type: 'text' })
   content: string;
 
+  @ApiProperty({
+    description: '썸네일 URL',
+    example: 'https://example.com/thumbnail.jpg',
+    required: false,
+  })
   @Column({ name: 'thumbnail', length: 255, nullable: true })
   thumbnail: string;
 
+  @ApiProperty({
+    description: '생성 날짜',
+    example: '2024-08-28T14:00:00.000Z',
+  })
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
 
+  @ApiProperty({
+    description: '수정 날짜',
+    example: '2024-08-29T14:00:00.000Z',
+  })
   @UpdateDateColumn({ name: 'updated_at' })
   updatedAt: Date;
 
+  @ApiProperty({ description: '게시글 상태', example: 'active' })
   @Column({ name: 'status', length: 50 })
   status: string;
 
+  @ApiProperty({
+    description: '모임 날짜',
+    example: '2024-09-01T14:00:00.000Z',
+  })
   @Column({
     name: 'meeting_date',
     type: 'timestamp',

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -15,7 +15,7 @@ import { Review } from './review.entity';
 import { FriendRequest } from './friend-request.entity';
 import { Friendship } from './friendship.entity';
 import { Post } from './post.entity';
-import { PostParticipationRequest } from './post-participant-request.entity';
+import { PostParticipationRequest } from './post-participation-request.entity';
 import { PostParticipant } from './post-participant.entity';
 
 @Entity('user')

--- a/src/location/location.controller.ts
+++ b/src/location/location.controller.ts
@@ -77,7 +77,7 @@ export class LocationController {
   @ApiParam({
     name: 'province',
     description: '광역시/특별시/도',
-    example: '서울특별시',
+    example: '서울',
   })
   @ApiResponse({
     status: 200,

--- a/src/participant/dto/participant.dto.ts
+++ b/src/participant/dto/participant.dto.ts
@@ -1,0 +1,21 @@
+import { PickType } from '@nestjs/swagger';
+import { PostParticipationRequest } from '../../entities/post-participation-request.entity';
+import { PostParticipant } from '../../entities/post-participant.entity';
+
+export class CreateParticipationRequestDto extends PickType(
+  PostParticipationRequest,
+  ['postId', 'requesterId', 'addresseeId'] as const,
+) {}
+
+export class ParticipationRequestResponseDto extends PickType(
+  PostParticipationRequest,
+  ['requestId', 'postId', 'requesterId', 'addresseeId'] as const,
+) {}
+
+export class ParticipantResponseDto extends PickType(PostParticipant, [
+  'participantId',
+  'postId',
+  'userId',
+  'createdAt',
+  'updatedAt',
+] as const) {}

--- a/src/participant/dto/participant.dto.ts
+++ b/src/participant/dto/participant.dto.ts
@@ -4,7 +4,7 @@ import { PostParticipant } from '../../entities/post-participant.entity';
 
 export class CreateParticipationRequestDto extends PickType(
   PostParticipationRequest,
-  ['postId', 'requesterId', 'addresseeId'] as const,
+  ['postId', 'requesterId'] as const,
 ) {}
 
 export class ParticipationRequestResponseDto extends PickType(

--- a/src/participant/participant.controller.spec.ts
+++ b/src/participant/participant.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ParticipantController } from './participant.controller';
+
+describe('ParticipantController', () => {
+  let controller: ParticipantController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ParticipantController],
+    }).compile();
+
+    controller = module.get<ParticipantController>(ParticipantController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/participant/participant.controller.ts
+++ b/src/participant/participant.controller.ts
@@ -1,0 +1,61 @@
+import { Controller, Post, Delete, Get, Param, Body } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ParticipantService } from './participant.service';
+import {
+  CreateParticipationRequestDto,
+  ParticipationRequestResponseDto,
+  ParticipantResponseDto,
+} from './dto/participant.dto';
+@ApiTags('여행 참여')
+@Controller('participant')
+export class ParticipantController {
+  constructor(private readonly participationService: ParticipantService) {}
+
+  @Post('request')
+  @ApiOperation({ summary: '참여 요청' })
+  @ApiResponse({ status: 201, type: ParticipationRequestResponseDto })
+  async createParticipationRequest(
+    @Body() createDto: CreateParticipationRequestDto,
+  ): Promise<ParticipationRequestResponseDto> {
+    return this.participationService.createParticipationRequest(createDto);
+  }
+
+  @Post('request/:requestId/accept')
+  @ApiOperation({ summary: '참여 요청 수락' })
+  @ApiResponse({ status: 200, type: ParticipantResponseDto })
+  async acceptParticipationRequest(
+    @Param('requestId') requestId: number,
+  ): Promise<ParticipantResponseDto> {
+    return this.participationService.acceptParticipationRequest(requestId);
+  }
+
+  @Delete('request/:requestId/decline')
+  @ApiOperation({ summary: '참여 요청 거절' })
+  @ApiResponse({
+    status: 200,
+    description: '참여 요청이 거절 및 취소 되었습니다.',
+  })
+  async declineParticipationRequest(
+    @Param('requestId') requestId: number,
+  ): Promise<object> {
+    return this.participationService.declineParticipationRequest(requestId);
+  }
+
+  @Get('post/:postId')
+  @ApiOperation({ summary: '특정 게시글의 참여자 조회' })
+  @ApiResponse({ status: 200, type: [ParticipantResponseDto] })
+  async getParticipantsByPostId(
+    @Param('postId') postId: number,
+  ): Promise<ParticipantResponseDto[]> {
+    return this.participationService.getParticipantsByPostId(postId);
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: '참여 취소' })
+  @ApiResponse({ status: 204 })
+  async cancelParticipation(@Param('id') id: number): Promise<void> {
+    return this.participationService.cancelParticipation(id);
+  }
+
+  // 특정 유저의 참여 정보 조회
+}

--- a/src/participant/participant.module.ts
+++ b/src/participant/participant.module.ts
@@ -4,10 +4,17 @@ import { ParticipantController } from './participant.controller';
 import { ParticipantService } from './participant.service';
 import { PostParticipationRequest } from '../entities/post-participation-request.entity';
 import { PostParticipant } from '../entities/post-participant.entity';
+import { Post } from 'src/entities/post.entity';
+import { UserBlock } from 'src/entities/user-block.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([PostParticipationRequest, PostParticipant]),
+    TypeOrmModule.forFeature([
+      PostParticipationRequest,
+      PostParticipant,
+      Post,
+      UserBlock,
+    ]),
   ],
   controllers: [ParticipantController],
   providers: [ParticipantService],

--- a/src/participant/participant.module.ts
+++ b/src/participant/participant.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ParticipantController } from './participant.controller';
+import { ParticipantService } from './participant.service';
+import { PostParticipationRequest } from '../entities/post-participation-request.entity';
+import { PostParticipant } from '../entities/post-participant.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([PostParticipationRequest, PostParticipant]),
+  ],
+  controllers: [ParticipantController],
+  providers: [ParticipantService],
+  exports: [ParticipantService],
+})
+export class ParticipantModule {}

--- a/src/participant/participant.service.spec.ts
+++ b/src/participant/participant.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ParticipantService } from './participant.service';
+
+describe('ParticipantService', () => {
+  let service: ParticipantService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ParticipantService],
+    }).compile();
+
+    service = module.get<ParticipantService>(ParticipantService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/participant/participant.service.ts
+++ b/src/participant/participant.service.ts
@@ -1,0 +1,103 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { PostParticipationRequest } from '../entities/post-participation-request.entity';
+import { PostParticipant } from '../entities/post-participant.entity';
+import {
+  CreateParticipationRequestDto,
+  ParticipationRequestResponseDto,
+  ParticipantResponseDto,
+} from './dto/participant.dto';
+@Injectable()
+export class ParticipantService {
+  constructor(
+    @InjectRepository(PostParticipationRequest)
+    private participationRequestRepository: Repository<PostParticipationRequest>,
+    @InjectRepository(PostParticipant)
+    private participantRepository: Repository<PostParticipant>,
+  ) {}
+
+  async createParticipationRequest(
+    createDto: CreateParticipationRequestDto,
+  ): Promise<ParticipationRequestResponseDto> {
+    const request = this.participationRequestRepository.create(createDto);
+    const savedRequest =
+      await this.participationRequestRepository.save(request);
+    return this.mapToParticipationRequestResponseDto(savedRequest);
+  }
+
+  async acceptParticipationRequest(
+    requestId: number,
+  ): Promise<ParticipantResponseDto> {
+    const request = await this.participationRequestRepository.findOne({
+      where: { requestId },
+    });
+
+    if (!request) {
+      throw new NotFoundException('참여 요청 정보를 찾을 수 없습니다.');
+    }
+
+    const participant = this.participantRepository.create({
+      postId: request.postId,
+      participantId: request.requesterId,
+    });
+    await this.participantRepository.save(participant);
+
+    await this.participationRequestRepository.delete(request);
+
+    return this.mapToParticipantResponseDto(participant);
+  }
+
+  async declineParticipationRequest(requestId: number): Promise<object> {
+    const request = await this.participationRequestRepository.findOne({
+      where: { requestId },
+    });
+
+    if (!request) {
+      throw new NotFoundException('참여 요청 정보를 찾을 수 없습니다.');
+    }
+
+    await this.participationRequestRepository.delete(request);
+
+    return { message: '참여 요청이 거절 및 취소 되었습니다.' };
+  }
+
+  async getParticipantsByPostId(
+    postId: number,
+  ): Promise<ParticipantResponseDto[]> {
+    const participants = await this.participantRepository.find({
+      where: { postId },
+    });
+    return participants.map(this.mapToParticipantResponseDto);
+  }
+
+  async cancelParticipation(id: number): Promise<void> {
+    const result = await this.participantRepository.delete(id);
+    if (result.affected === 0) {
+      throw new NotFoundException('참여 정보를 찾을 수 없습니다.');
+    }
+  }
+
+  private mapToParticipationRequestResponseDto(
+    request: PostParticipationRequest,
+  ): ParticipationRequestResponseDto {
+    return {
+      requestId: request.requestId,
+      postId: request.postId,
+      requesterId: request.requesterId,
+      addresseeId: request.addresseeId,
+    };
+  }
+
+  private mapToParticipantResponseDto(
+    participant: PostParticipant,
+  ): ParticipantResponseDto {
+    return {
+      participantId: participant.participantId,
+      postId: participant.postId,
+      userId: participant.userId,
+      createdAt: participant.createdAt,
+      updatedAt: participant.updatedAt,
+    };
+  }
+}

--- a/src/post/dto/post.dto.ts
+++ b/src/post/dto/post.dto.ts
@@ -1,132 +1,58 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, PartialType, PickType } from '@nestjs/swagger';
+import { Post } from '../../entities/post.entity';
 
-export class CreatePostDto {
-  @ApiProperty({ description: '게시글 제목', example: 'NestJS 게시글 예제' })
-  title: string;
-
+export class CreatePostDto extends PickType(Post, [
+  'title',
+  'content',
+  'thumbnail',
+  'userId',
+  'locationId',
+  'meetingDate',
+] as const) {
   @ApiProperty({
-    description: '게시글 내용',
-    example: '이것은 예제 게시글입니다.',
-  })
-  content: string;
-
-  @ApiProperty({
-    description: '썸네일 URL',
-    example: 'https://example.com/thumbnail.jpg',
+    description: '태그 ID 목록',
+    example: [1, 2, 3],
     required: false,
   })
-  thumbnail?: string;
-
-  @ApiProperty({ description: '사용자 ID', example: 1 })
-  userId: number;
-
-  @ApiProperty({ description: '위치 ID', example: 1 })
-  locationId: number;
-
-  @ApiProperty({
-    description: '모임 날짜',
-    example: '2024-09-01T14:00:00.000Z',
-  })
-  meetingDate: Date;
-
-  @ApiProperty({
-    description: '태그 목록',
-    example: ['NestJS', 'TypeScript'],
-    required: false,
-  })
-  tags?: string[];
+  tagIds?: number[];
 }
 
-export class UpdatePostDto {
+export class UpdatePostDto extends PartialType(
+  PickType(Post, [
+    'title',
+    'content',
+    'thumbnail',
+    'locationId',
+    'meetingDate',
+  ] as const),
+) {
   @ApiProperty({
-    description: '게시글 제목',
-    example: 'NestJS 게시글 예제',
+    description: '태그 ID 목록',
+    example: [1, 2, 3],
     required: false,
   })
-  title?: string;
-
-  @ApiProperty({
-    description: '게시글 내용',
-    example: '이것은 예제 게시글입니다.',
-    required: false,
-  })
-  content?: string;
-
-  @ApiProperty({
-    description: '썸네일 URL',
-    example: 'https://example.com/thumbnail.jpg',
-    required: false,
-  })
-  thumbnail?: string;
-
-  @ApiProperty({ description: '위치 ID', example: 1, required: false })
-  locationId?: number;
-
-  @ApiProperty({
-    description: '모임 날짜',
-    example: '2024-09-01T14:00:00.000Z',
-    required: false,
-  })
-  meetingDate?: Date;
-
-  @ApiProperty({
-    description: '태그 목록',
-    example: ['NestJS', 'TypeScript'],
-    required: false,
-  })
-  tags?: string[];
+  tagIds?: number[];
 }
 
-export class PostResponseDto {
-  @ApiProperty({ description: '게시글 ID', example: 1 })
-  postId: number;
-
-  @ApiProperty({ description: '게시글 제목', example: 'NestJS 게시글 예제' })
-  title: string;
-
+export class PostResponseDto extends PickType(Post, [
+  'postId',
+  'title',
+  'content',
+  'thumbnail',
+  'userId',
+  'locationId',
+  'meetingDate',
+  'createdAt',
+  'updatedAt',
+  'status',
+] as const) {
   @ApiProperty({
-    description: '게시글 내용',
-    example: '이것은 예제 게시글입니다.',
-  })
-  content: string;
-
-  @ApiProperty({
-    description: '썸네일 URL',
-    example: 'https://example.com/thumbnail.jpg',
-  })
-  thumbnail?: string;
-
-  @ApiProperty({ description: '사용자 ID', example: 1 })
-  userId: number;
-
-  @ApiProperty({ description: '위치 ID', example: 1 })
-  locationId: number;
-
-  @ApiProperty({
-    description: '모임 날짜',
-    example: '2024-09-01T14:00:00.000Z',
-  })
-  meetingDate: Date;
-
-  @ApiProperty({
-    description: '생성 날짜',
-    example: '2024-08-28T14:00:00.000Z',
-  })
-  createdAt: Date;
-
-  @ApiProperty({
-    description: '수정 날짜',
-    example: '2024-08-29T14:00:00.000Z',
-  })
-  updatedAt: Date;
-
-  @ApiProperty({ description: '게시글 상태', example: 'active' })
-  status: string;
-
-  @ApiProperty({
-    description: '태그 목록',
-    example: ['NestJS', 'TypeScript'],
+    description: '태그 정보 목록',
+    example: [
+      { id: 1, name: 'NestJS' },
+      { id: 2, name: 'TypeScript' },
+    ],
     required: false,
   })
-  tags: string[];
+  tags: { id: number; name: string }[];
 }

--- a/src/post/post.controller.ts
+++ b/src/post/post.controller.ts
@@ -8,7 +8,7 @@ import {
   Body,
   HttpStatus,
 } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { PostService } from './post.service';
 import { CreatePostDto, UpdatePostDto, PostResponseDto } from './dto/post.dto';
 
@@ -59,10 +59,15 @@ export class PostController {
     return this.postService.getPostById(postId);
   }
 
-  @Put(':id')
+  @Put(':postId')
   @ApiOperation({
     summary: '게시글 수정',
-    description: 'ID로 특정 게시글을 수정합니다.',
+    description: '특정 ID의 게시글을 수정합니다.',
+  })
+  @ApiParam({
+    name: 'postId',
+    description: '수정할 게시글의 ID',
+    type: 'number',
   })
   @ApiResponse({
     status: HttpStatus.OK,
@@ -70,7 +75,7 @@ export class PostController {
     type: PostResponseDto,
   })
   updatePost(
-    @Param('id') postId: number,
+    @Param('postId') postId: number,
     @Body() updatePostDto: UpdatePostDto,
   ): Promise<PostResponseDto> {
     return this.postService.updatePost(postId, updatePostDto);
@@ -89,18 +94,23 @@ export class PostController {
     return this.postService.deletePost(postId);
   }
 
-  @Get('tag/:tagName')
+  @Get('tag/:tagId')
   @ApiOperation({
     summary: '특정 태그로 게시글 조회',
-    description: '특정 태그에 해당하는 게시글을 조회합니다.',
+    description: '특정 태그 ID에 해당하는 게시글을 조회합니다.',
+  })
+  @ApiParam({
+    name: 'tagId',
+    description: '조회할 태그의 ID',
+    type: 'number',
   })
   @ApiResponse({
     status: HttpStatus.OK,
     description: '태그로 필터링된 게시글 조회 성공',
     type: [PostResponseDto],
   })
-  getPostsByTag(@Param('tagName') tagName: string): Promise<PostResponseDto[]> {
-    return this.postService.getPostsByTag(tagName);
+  getPostsByTag(@Param('tagId') tagId: number): Promise<PostResponseDto[]> {
+    return this.postService.getPostsByTag(tagId);
   }
 
   @Get('location/:locationId')

--- a/src/tag/tag.controller.ts
+++ b/src/tag/tag.controller.ts
@@ -45,6 +45,20 @@ export class TagController {
     return this.tagService.getAllTags();
   }
 
+  @Get(':name')
+  @ApiOperation({
+    summary: '태그 조회',
+    description: '대크 이름으로 태그를 조회합니다.',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: '태그 조회 성공',
+    type: TagResponseDto,
+  })
+  getTagByName(@Param('name') tagName: string): Promise<TagResponseDto> {
+    return this.tagService.getTagByName(tagName);
+  }
+
   @Get(':id')
   @ApiOperation({
     summary: '태그 조회',

--- a/src/tag/tag.controller.ts
+++ b/src/tag/tag.controller.ts
@@ -45,32 +45,26 @@ export class TagController {
     return this.tagService.getAllTags();
   }
 
-  @Get(':name')
+  @Get(':nameOrId')
   @ApiOperation({
     summary: '태그 조회',
-    description: '대크 이름으로 태그를 조회합니다.',
+    description: '이름이나 ID로 태그를 조회합니다.',
   })
   @ApiResponse({
     status: HttpStatus.OK,
     description: '태그 조회 성공',
     type: TagResponseDto,
   })
-  getTagByName(@Param('name') tagName: string): Promise<TagResponseDto> {
-    return this.tagService.getTagByName(tagName);
-  }
-
-  @Get(':id')
-  @ApiOperation({
-    summary: '태그 조회',
-    description: 'ID로 태그를 조회합니다.',
-  })
-  @ApiResponse({
-    status: HttpStatus.OK,
-    description: '태그 조회 성공',
-    type: TagResponseDto,
-  })
-  getTagById(@Param('id') tagId: number): Promise<TagResponseDto> {
-    return this.tagService.getTagById(tagId);
+  async getTagByNameOrId(
+    @Param('nameOrId') nameOrId: string,
+  ): Promise<TagResponseDto> {
+    if (!isNaN(Number(nameOrId))) {
+      // 숫자라면 ID로 간주
+      return this.tagService.getTagById(Number(nameOrId));
+    } else {
+      // 그렇지 않다면 이름으로 간주
+      return this.tagService.getTagByName(nameOrId);
+    }
   }
 
   @Put(':id')

--- a/src/tag/tag.service.ts
+++ b/src/tag/tag.service.ts
@@ -44,4 +44,12 @@ export class TagService {
       throw new NotFoundException(`ID가 ${tagId}인 태그를 찾을 수 없습니다.`);
     }
   }
+
+  async getTagByName(tagName: string): Promise<TagResponseDto> {
+    const tag = await this.tagRepository.findOne({ where: { name: tagName } });
+    if (!tag) {
+      throw new NotFoundException(`ID가 ${tagName}인 태그를 찾을 수 없습니다.`);
+    }
+    return tag;
+  }
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -36,21 +36,30 @@ export class UserService {
     private readonly userRatingRepository: Repository<UserRating>,
   ) {}
 
-  async getUserById(id: number): Promise<User> {
+  async getUserById(id: number): Promise<any> {
     this.logger.log(`사용자 정보 조회 요청. ID: ${id}`);
     if (!id || isNaN(id)) {
       throw new NotFoundException(`Invalid user ID: ${id}`);
     }
+
     const user = await this.userRepository.findOne({
       where: { userId: id },
-      relations: ['oauths'],
+      relations: ['oauths', 'userLocations'],
     });
+
     if (!user) {
       throw new NotFoundException(`User with ID ${id} not found`);
     }
-    return user;
-  }
+    const locationId = user.userLocations[0]?.locationId;
 
+    const transformedUser = {
+      ...user,
+      locationId: locationId,
+    };
+    delete transformedUser.userLocations;
+
+    return transformedUser;
+  }
   async updateUsername(
     id: number,
     usernameUpdateDto: UsernameUpdateDto,


### PR DESCRIPTION
이 풀 리퀘스트는 `develop` 브랜치를 `main` 브랜치에 병합합니다. 이번 병합에는 다음과 같은 주요 기능과 수정 사항이 포함되어 있습니다:

- **참여 요청 기능 개선:**
  - 참여 요청 생성 시, `addresseeId`를 자동으로 게시글 작성자의 `userId`로 설정하도록 구현했습니다.
  - 요청자가 본인에게 참여 요청을 보내지 못하도록 검증 로직을 추가했습니다.
  - 차단된 사용자가 참여 요청을 보내거나 수락할 수 없도록 차단 여부 확인 로직을 구현했습니다.

- **버그 수정:**
  - ID로 태그를 조회할 때 이름으로 조회하는 기능과 충돌하던 문제를 해결했습니다.
  - 참여 프로세스 전반에 걸쳐 입력 검증 및 오류 처리를 개선했습니다.

변경 사항을 검토하시고, 문제가 없으면 `main` 브랜치로 병합해 주시기 바랍니다. 이 변경 사항들은 테스트 완료되었으며, 배포 준비가 되어 있습니다.